### PR TITLE
design mode

### DIFF
--- a/src/itstack-demo-rpc/itstack-demo-rpc-consumer/pom.xml
+++ b/src/itstack-demo-rpc/itstack-demo-rpc-consumer/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.5</version>
+            <version>4.3.6</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.2.5 to 4.3.6.

Signed-off-by: dependabot[bot] <support@github.com>