### PR TITLE
Update 2021-04-18-面经手册 · 第30篇《关于 Spring 中 getBean 的全流程源码解析》.md

### DIFF
--- a/docs/md/java/interview/2021-04-18-面经手册 · 第30篇《关于 Spring 中 getBean 的全流程源码解析》.md
+++ b/docs/md/java/interview/2021-04-18-面经手册 · 第30篇《关于 Spring 中 getBean 的全流程源码解析》.md
@@ -515,7 +515,7 @@ protected Object getSingleton(String beanName, boolean allowEarlyReference) {
 			if (singletonObject == null && allowEarlyReference) {
 				ObjectFactory<?> singletonFactory = this.singletonFactories.get(beanName);
 				if (singletonFactory != null) {
-                    // 加入到三级缓存，暴漏早期对象用于解决三级缓存
+                    // 加入到三级缓存，暴漏早期对象用于解决循环依赖
 					singletonObject = singletonFactory.getObject();  
 					this.earlySingletonObjects.put(beanName, singletonObject);
 					this.singletonFactories.remove(beanName);


### PR DESCRIPTION
注释错误，“加入到三级缓存，暴漏早期对象用于解决三级缓存” -> "加入到三级缓存，暴漏早期对象用于解决循环依赖"