### PR TITLE
Update 2020-11-11-面经手册 · 第17篇《码农会锁，ReentrantLock之AQS原理分析和实践使用》.md

### DIFF
--- a/docs/md/java/interview/2020-11-11-面经手册 · 第17篇《码农会锁，ReentrantLock之AQS原理分析和实践使用》.md
+++ b/docs/md/java/interview/2020-11-11-面经手册 · 第17篇《码农会锁，ReentrantLock之AQS原理分析和实践使用》.md
@@ -428,7 +428,7 @@ private final boolean parkAndCheckInterrupt() {
 }    
 ```
 
-- 当方法 `shouldParkAfterFailedAcquire` 返回 false 时，则执行 parkAndCheckInterrupt() 方法。
+- 当方法 `shouldParkAfterFailedAcquire` 返回 false 时，代表同步器改变了前驱节点的状态为 `SIGNAL`，在下一次循环中， `shouldParkAfterFailedAcquire` 返回 true，再执行 parkAndCheckInterrupt() 方法。
 - 那么，这一段代码就是对线程的挂起操作，`LockSupport.park(this);`。
 - `Thread.interrupted()` 检查当前线程的中断标识。
 


### PR DESCRIPTION
4.8 parkAndCheckInterrupt 
if 的判断说的有点问题，因为是死循环，所以 `shouldParkAfterFailedAcquire()` 返回 false 后，&& 后面的 `parkAndCheckInterrupt()` 方法就不会执行了，在下一次循环才会执行